### PR TITLE
feat: auto model routing for SkillFlows

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -91,7 +91,7 @@ export {
 } from "./workflows.js";
 // Model routing — consumed by @open-gitagent/voice to pick a per-step model.
 export { resolveRoutedModel } from "./model-routing.js";
-export type { ModelTier, RoutingConfig, RouteInput, RouteResult } from "./model-routing.js";
+export type { ModelTier, RoutingConfig, RouteInput, RouteResult, RouteQuery, RouteDeps } from "./model-routing.js";
 export {
 	discoverSchedules,
 	saveSchedule,

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -89,6 +89,9 @@ export {
 	saveFlowDefinition,
 	deleteFlowDefinition,
 } from "./workflows.js";
+// Model routing — consumed by @open-gitagent/voice to pick a per-step model.
+export { resolveRoutedModel } from "./model-routing.js";
+export type { ModelTier, RoutingConfig, RouteInput, RouteResult } from "./model-routing.js";
 export {
 	discoverSchedules,
 	saveSchedule,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -42,6 +42,12 @@ export interface AgentManifest {
 			top_k?: number;
 			stop_sequences?: string[];
 		};
+		routing?: {
+			enabled?: boolean;
+			lightweight?: string;
+			reasoning?: string;
+			rules?: Array<{ tier: "lightweight" | "reasoning"; match: string[] }>;
+		};
 	};
 	tools: string[];
 	skills?: string[];

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -1,0 +1,143 @@
+// Auto Model Routing (issue #48)
+//
+// Classifies each task in an agent workflow by complexity and routes it to the
+// most appropriate model: lightweight tasks (summarize/extract/classify/
+// transform) go to a cheap model, while reasoning-intensive tasks (search,
+// planning, decision-making, tool orchestration, complex problem solving)
+// stay on the configured reasoning model. Explicit per-step / per-skill model
+// settings always win, and anything unresolved falls back to the primary model.
+
+export type ModelTier = "lightweight" | "reasoning";
+
+export interface RoutingConfig {
+	/** Master switch. Defaults to true when a routing block is present. */
+	enabled?: boolean;
+	/** Concrete model id for lightweight tasks, e.g. "openai:gpt-4o-mini". */
+	lightweight?: string;
+	/** Concrete model id for reasoning tasks, e.g. "openai:gpt-4o". */
+	reasoning?: string;
+	/** User overrides for classification — first matching rule wins. */
+	rules?: Array<{ tier: ModelTier; match: string[] }>;
+}
+
+export interface RouteInput {
+	/** Explicit per-step model (highest priority). May be an alias or model id. */
+	stepModel?: string;
+	/** Per-skill default model from SKILL.md frontmatter. May be an alias or id. */
+	skillModel?: string;
+	/** Text used to classify the task (typically skill name + step prompt). */
+	classifyText: string;
+	/** Routing configuration from agent.yaml (model.routing). */
+	routing?: RoutingConfig;
+	/** The agent's primary/preferred model — the ultimate fallback. */
+	primaryModel?: string;
+}
+
+export interface RouteResult {
+	/** Resolved concrete "provider:model" string (undefined → let runtime decide). */
+	model?: string;
+	/** The complexity tier, when the model came from automatic classification. */
+	tier: ModelTier | null;
+	/** Where the decision came from. */
+	source: "step" | "skill" | "auto" | "fallback";
+}
+
+// Default task-to-tier keyword framework, derived directly from the issue's
+// recommended task-type table. Matched against word starts so "summarize",
+// "summary" and "summarization" all hit "summ", without false positives like
+// "already" matching "read".
+const DEFAULT_LIGHTWEIGHT = [
+	"summ", "extract", "classif", "transform", "format", "convert",
+	"parse", "fetch", "read", "load", "lookup", "normaliz", "translat",
+	"rephrase", "rewrite", "tag", "label", "render",
+];
+const DEFAULT_REASONING = [
+	"search", "analy", "plan", "decid", "decision", "orchestrat", "solve",
+	"reason", "validat", "evaluat", "review", "audit", "diagnos", "debug",
+	"architect", "design", "strateg", "investigat", "assess", "judge",
+	"verify", "critique", "infer", "deduc",
+];
+
+function matchesAny(text: string, keywords: string[]): boolean {
+	for (const kw of keywords) {
+		// Word-start boundary: keyword must begin a word.
+		const re = new RegExp(`\\b${kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i");
+		if (re.test(text)) return true;
+	}
+	return false;
+}
+
+/**
+ * Classify a task into a complexity tier. User-defined rules (from
+ * model.routing.rules) take precedence over the built-in defaults. When a task
+ * matches neither — or matches both — it defaults to "reasoning" so that
+ * reasoning quality is never sacrificed to save cost.
+ */
+export function classifyTaskTier(
+	classifyText: string,
+	rules?: Array<{ tier: ModelTier; match: string[] }>,
+): ModelTier {
+	const text = classifyText || "";
+
+	// User overrides first, in declaration order.
+	if (rules) {
+		for (const rule of rules) {
+			if (Array.isArray(rule.match) && matchesAny(text, rule.match)) {
+				return rule.tier;
+			}
+		}
+	}
+
+	const hasReasoning = matchesAny(text, DEFAULT_REASONING);
+	if (hasReasoning) return "reasoning";
+	const hasLightweight = matchesAny(text, DEFAULT_LIGHTWEIGHT);
+	if (hasLightweight) return "lightweight";
+
+	// Unknown → keep quality high.
+	return "reasoning";
+}
+
+/**
+ * Resolve a model reference that may be a routing-tier alias
+ * ("lightweight"/"reasoning") or a literal "provider:model" id.
+ */
+export function resolveModelAlias(ref: string | undefined, routing?: RoutingConfig): string | undefined {
+	if (!ref) return undefined;
+	if (ref === "lightweight") return routing?.lightweight || undefined;
+	if (ref === "reasoning") return routing?.reasoning || undefined;
+	return ref;
+}
+
+/**
+ * Decide which model a task should run on. Precedence:
+ *   1. explicit per-step model      (source: "step")
+ *   2. per-skill declared model      (source: "skill")
+ *   3. automatic classification      (source: "auto")  — when routing is enabled
+ *   4. primary/preferred model       (source: "fallback")
+ *
+ * Automatic routing is active only when a routing block is present and not
+ * disabled. If classification picks a tier with no configured model, it falls
+ * through to the primary model (fallback on routing failure).
+ */
+export function resolveRoutedModel(input: RouteInput): RouteResult {
+	const { stepModel, skillModel, classifyText, routing, primaryModel } = input;
+
+	// 1. Explicit per-step override.
+	const fromStep = resolveModelAlias(stepModel, routing);
+	if (fromStep) return { model: fromStep, tier: null, source: "step" };
+
+	// 2. Per-skill declared default.
+	const fromSkill = resolveModelAlias(skillModel, routing);
+	if (fromSkill) return { model: fromSkill, tier: null, source: "skill" };
+
+	// 3. Automatic classification (opt-in via a routing block).
+	const autoEnabled = !!routing && routing.enabled !== false && !!(routing.lightweight || routing.reasoning);
+	if (autoEnabled) {
+		const tier = classifyTaskTier(classifyText, routing!.rules);
+		const model = tier === "lightweight" ? routing!.lightweight : routing!.reasoning;
+		if (model) return { model, tier, source: "auto" };
+	}
+
+	// 4. Fallback to the primary model.
+	return { model: primaryModel, tier: null, source: "fallback" };
+}

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -1,7 +1,7 @@
-// Classifies each SkillFlow step by complexity and resolves the model it should
-// run on: lightweight tasks (summarize/extract/classify/transform) to a cheap
-// model, reasoning-heavy tasks to the configured reasoning model. Explicit
-// per-step / per-skill settings win; anything unresolved falls back to primary.
+// Resolves which model each SkillFlow step runs on. Explicit per-step / per-skill
+// settings win; otherwise the step is classified by one call to the lightweight
+// model via an injected `query` (RouteDeps), falling back to a keyword heuristic
+// when no `query` is supplied.
 
 export type ModelTier = "lightweight" | "reasoning";
 
@@ -12,7 +12,7 @@ export interface RoutingConfig {
 	lightweight?: string;
 	/** Model id for reasoning tasks, e.g. "openai:gpt-4o". */
 	reasoning?: string;
-	/** Classification overrides — first matching rule wins. */
+	/** Classification overrides — first matching rule wins, before the LLM/keyword step. */
 	rules?: Array<{ tier: ModelTier; match: string[] }>;
 }
 
@@ -28,6 +28,25 @@ export interface RouteInput {
 	primaryModel?: string;
 }
 
+/** Minimal shape of the SDK `query()` used to classify — injected so core stays decoupled and testable. */
+export type RouteQuery = (opts: {
+	prompt: string;
+	model?: string;
+	dir?: string;
+	env?: string;
+	systemPrompt?: string;
+	maxTurns?: number;
+	tools?: [];
+	replaceBuiltinTools?: boolean;
+}) => AsyncIterable<{ type: string; content?: string }>;
+
+export interface RouteDeps {
+	/** When present (and routing is enabled) classification runs one LLM call on the lightweight model. */
+	query?: RouteQuery;
+	dir?: string;
+	env?: string;
+}
+
 export interface RouteResult {
 	/** Resolved "provider:model" (undefined → let the runtime decide). */
 	model?: string;
@@ -36,18 +55,19 @@ export interface RouteResult {
 	source: "step" | "skill" | "auto" | "fallback";
 }
 
-// Matched against word starts, so "summarize"/"summary"/"summarization" all hit
-// "summ" without "already" matching "read".
+// Keyword fallback, used only when no `query` is injected. Ambiguous verbs like
+// "search" that appear in both trivial and complex prompts are deliberately left
+// out so they don't systematically overpay.
 const DEFAULT_LIGHTWEIGHT = [
 	"summ", "extract", "classif", "transform", "format", "convert",
 	"parse", "fetch", "read", "load", "lookup", "normaliz", "translat",
 	"rephrase", "rewrite", "tag", "label", "render",
 ];
 const DEFAULT_REASONING = [
-	"search", "analy", "plan", "decid", "decision", "orchestrat", "solve",
+	"analy", "plan", "decid", "decision", "orchestrat", "solve",
 	"reason", "validat", "evaluat", "review", "audit", "diagnos", "debug",
-	"architect", "design", "strateg", "investigat", "assess", "judge",
-	"verify", "critique", "infer", "deduc",
+	"architect", "design", "strateg", "investigat", "research", "assess",
+	"judge", "verify", "critique", "infer", "deduc",
 ];
 
 function matchesAny(text: string, keywords: string[]): boolean {
@@ -58,44 +78,90 @@ function matchesAny(text: string, keywords: string[]): boolean {
 	return false;
 }
 
+function matchRules(text: string, rules?: Array<{ tier: ModelTier; match: string[] }>): ModelTier | null {
+	if (rules) {
+		for (const rule of rules) {
+			if (Array.isArray(rule.match) && matchesAny(text, rule.match)) return rule.tier;
+		}
+	}
+	return null;
+}
+
 /**
- * Classify a task into a complexity tier. User rules take precedence over the
- * built-in defaults. A task that matches neither — or both — resolves to
- * "reasoning", so cost optimization never silently degrades quality.
+ * Keyword-based tier classification — the offline fallback. User rules win;
+ * otherwise a task that matches neither list (or both) resolves to "reasoning",
+ * so cost optimization never silently degrades quality.
  */
-export function classifyTaskTier(
+export function classifyByKeywords(
 	classifyText: string,
 	rules?: Array<{ tier: ModelTier; match: string[] }>,
 ): ModelTier {
 	const text = classifyText || "";
-
-	if (rules) {
-		for (const rule of rules) {
-			if (Array.isArray(rule.match) && matchesAny(text, rule.match)) {
-				return rule.tier;
-			}
-		}
-	}
-
+	const ruled = matchRules(text, rules);
+	if (ruled) return ruled;
 	if (matchesAny(text, DEFAULT_REASONING)) return "reasoning";
 	if (matchesAny(text, DEFAULT_LIGHTWEIGHT)) return "lightweight";
 	return "reasoning";
 }
 
-/** Resolve a tier alias ("lightweight"/"reasoning") or pass a model id through. */
+const CLASSIFY_INSTRUCTIONS =
+	`Classify the following agent task as exactly one word: "lightweight" or "reasoning".\n` +
+	`- lightweight: mechanical work with a known shape (summarize, extract, format, fetch, read, look up).\n` +
+	`- reasoning: needs analysis, planning, multi-step logic, or judgment.\n` +
+	`If unsure, answer "reasoning". Reply with only the single word.\n\nTask: `;
+
+/** One classification call on the lightweight model. Returns null if the call fails or is unparseable. */
+async function classifyViaLLM(text: string, model: string, deps: RouteDeps): Promise<ModelTier | null> {
+	try {
+		// Constrained one-shot: no tools, single turn — keeps it a single cheap call.
+		const result = deps.query!({
+			prompt: CLASSIFY_INSTRUCTIONS + text.trim(),
+			model,
+			dir: deps.dir,
+			env: deps.env,
+			systemPrompt: "You are a task classifier. Reply with exactly one word.",
+			maxTurns: 1,
+			tools: [],
+			replaceBuiltinTools: true,
+		});
+		let out = "";
+		for await (const msg of result) {
+			if (msg.type === "assistant" && msg.content) out += msg.content;
+		}
+		const answer = out.toLowerCase();
+		if (answer.includes("lightweight")) return "lightweight";
+		if (answer.includes("reason")) return "reasoning";
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve a tier alias ("lightweight"/"reasoning") or pass a model id through.
+ * Warns when an alias is requested but the routing block has no model for that
+ * tier, so silently falling through to the fallback stays observable.
+ */
 export function resolveModelAlias(ref: string | undefined, routing?: RoutingConfig): string | undefined {
 	if (!ref) return undefined;
-	if (ref === "lightweight") return routing?.lightweight || undefined;
-	if (ref === "reasoning") return routing?.reasoning || undefined;
+	if (ref === "lightweight" || ref === "reasoning") {
+		const configured = routing?.[ref];
+		if (!configured) {
+			console.warn(`[routing] tier alias '${ref}' requested but routing.${ref} is not configured; falling through`);
+			return undefined;
+		}
+		return configured;
+	}
 	return ref;
 }
 
 /**
  * Decide which model a task runs on, in precedence order: explicit per-step
  * model, per-skill model, automatic classification (only when a routing block
- * is present and enabled), then the primary model.
+ * is present and enabled), then the primary model. Automatic classification
+ * uses the injected `query` fn when available, else the keyword fallback.
  */
-export function resolveRoutedModel(input: RouteInput): RouteResult {
+export async function resolveRoutedModel(input: RouteInput, deps: RouteDeps = {}): Promise<RouteResult> {
 	const { stepModel, skillModel, classifyText, routing, primaryModel } = input;
 
 	const fromStep = resolveModelAlias(stepModel, routing);
@@ -106,7 +172,11 @@ export function resolveRoutedModel(input: RouteInput): RouteResult {
 
 	const autoEnabled = !!routing && routing.enabled !== false && !!(routing.lightweight || routing.reasoning);
 	if (autoEnabled) {
-		const tier = classifyTaskTier(classifyText, routing!.rules);
+		let tier = matchRules(classifyText || "", routing!.rules);
+		if (!tier && deps.query && routing!.lightweight) {
+			tier = await classifyViaLLM(classifyText, routing!.lightweight, deps);
+		}
+		if (!tier) tier = classifyByKeywords(classifyText, routing!.rules);
 		const model = tier === "lightweight" ? routing!.lightweight : routing!.reasoning;
 		if (model) return { model, tier, source: "auto" };
 	}

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -1,0 +1,115 @@
+// Classifies each SkillFlow step by complexity and resolves the model it should
+// run on: lightweight tasks (summarize/extract/classify/transform) to a cheap
+// model, reasoning-heavy tasks to the configured reasoning model. Explicit
+// per-step / per-skill settings win; anything unresolved falls back to primary.
+
+export type ModelTier = "lightweight" | "reasoning";
+
+export interface RoutingConfig {
+	/** Defaults to true when a routing block is present. */
+	enabled?: boolean;
+	/** Model id for lightweight tasks, e.g. "openai:gpt-4o-mini". */
+	lightweight?: string;
+	/** Model id for reasoning tasks, e.g. "openai:gpt-4o". */
+	reasoning?: string;
+	/** Classification overrides — first matching rule wins. */
+	rules?: Array<{ tier: ModelTier; match: string[] }>;
+}
+
+export interface RouteInput {
+	/** Explicit per-step model (highest priority); alias or model id. */
+	stepModel?: string;
+	/** Per-skill default from SKILL.md frontmatter; alias or model id. */
+	skillModel?: string;
+	/** Text used to classify the task (skill name + step prompt). */
+	classifyText: string;
+	routing?: RoutingConfig;
+	/** The agent's preferred model — the ultimate fallback. */
+	primaryModel?: string;
+}
+
+export interface RouteResult {
+	/** Resolved "provider:model" (undefined → let the runtime decide). */
+	model?: string;
+	/** Tier, when the model came from automatic classification. */
+	tier: ModelTier | null;
+	source: "step" | "skill" | "auto" | "fallback";
+}
+
+// Matched against word starts, so "summarize"/"summary"/"summarization" all hit
+// "summ" without "already" matching "read".
+const DEFAULT_LIGHTWEIGHT = [
+	"summ", "extract", "classif", "transform", "format", "convert",
+	"parse", "fetch", "read", "load", "lookup", "normaliz", "translat",
+	"rephrase", "rewrite", "tag", "label", "render",
+];
+const DEFAULT_REASONING = [
+	"search", "analy", "plan", "decid", "decision", "orchestrat", "solve",
+	"reason", "validat", "evaluat", "review", "audit", "diagnos", "debug",
+	"architect", "design", "strateg", "investigat", "assess", "judge",
+	"verify", "critique", "infer", "deduc",
+];
+
+function matchesAny(text: string, keywords: string[]): boolean {
+	for (const kw of keywords) {
+		const re = new RegExp(`\\b${kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`, "i");
+		if (re.test(text)) return true;
+	}
+	return false;
+}
+
+/**
+ * Classify a task into a complexity tier. User rules take precedence over the
+ * built-in defaults. A task that matches neither — or both — resolves to
+ * "reasoning", so cost optimization never silently degrades quality.
+ */
+export function classifyTaskTier(
+	classifyText: string,
+	rules?: Array<{ tier: ModelTier; match: string[] }>,
+): ModelTier {
+	const text = classifyText || "";
+
+	if (rules) {
+		for (const rule of rules) {
+			if (Array.isArray(rule.match) && matchesAny(text, rule.match)) {
+				return rule.tier;
+			}
+		}
+	}
+
+	if (matchesAny(text, DEFAULT_REASONING)) return "reasoning";
+	if (matchesAny(text, DEFAULT_LIGHTWEIGHT)) return "lightweight";
+	return "reasoning";
+}
+
+/** Resolve a tier alias ("lightweight"/"reasoning") or pass a model id through. */
+export function resolveModelAlias(ref: string | undefined, routing?: RoutingConfig): string | undefined {
+	if (!ref) return undefined;
+	if (ref === "lightweight") return routing?.lightweight || undefined;
+	if (ref === "reasoning") return routing?.reasoning || undefined;
+	return ref;
+}
+
+/**
+ * Decide which model a task runs on, in precedence order: explicit per-step
+ * model, per-skill model, automatic classification (only when a routing block
+ * is present and enabled), then the primary model.
+ */
+export function resolveRoutedModel(input: RouteInput): RouteResult {
+	const { stepModel, skillModel, classifyText, routing, primaryModel } = input;
+
+	const fromStep = resolveModelAlias(stepModel, routing);
+	if (fromStep) return { model: fromStep, tier: null, source: "step" };
+
+	const fromSkill = resolveModelAlias(skillModel, routing);
+	if (fromSkill) return { model: fromSkill, tier: null, source: "skill" };
+
+	const autoEnabled = !!routing && routing.enabled !== false && !!(routing.lightweight || routing.reasoning);
+	if (autoEnabled) {
+		const tier = classifyTaskTier(classifyText, routing!.rules);
+		const model = tier === "lightweight" ? routing!.lightweight : routing!.reasoning;
+		if (model) return { model, tier, source: "auto" };
+	}
+
+	return { model: primaryModel, tier: null, source: "fallback" };
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -11,6 +11,7 @@ export interface SkillMetadata {
 	usage_count?: number;
 	success_count?: number;
 	failure_count?: number;
+	model?: string;
 }
 
 export interface ParsedSkill extends SkillMetadata {
@@ -96,6 +97,7 @@ export async function discoverSkills(agentDir: string): Promise<SkillMetadata[]>
 		if (typeof frontmatter.usage_count === "number") meta.usage_count = frontmatter.usage_count;
 		if (typeof frontmatter.success_count === "number") meta.success_count = frontmatter.success_count;
 		if (typeof frontmatter.failure_count === "number") meta.failure_count = frontmatter.failure_count;
+		if (typeof frontmatter.model === "string") meta.model = frontmatter.model;
 
 		skills.push(meta);
 	}

--- a/src/voice/server.ts
+++ b/src/voice/server.ts
@@ -18,6 +18,8 @@ import { discoverWorkflows, loadFlowDefinition, saveFlowDefinition, deleteFlowDe
 import { discoverSchedules, saveSchedule, deleteSchedule, updateScheduleMeta } from "../schedules.js";
 import { startScheduler, stopScheduler, reloadSchedules, executeScheduledJob } from "../schedule-runner.js";
 import cron from "node-cron";
+import yaml from "js-yaml";
+import { resolveRoutedModel, type RoutingConfig } from "../model-routing.js";
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
@@ -638,10 +640,16 @@ export async function startVoiceServer(opts: VoiceServerOptions): Promise<() => 
 
 	const port = opts.port || 3333;
 	let agentName = "GitAgent";
+	// Auto Model Routing config from agent.yaml (model.routing). Issue #48.
+	let modelRouting: RoutingConfig | undefined;
 	try {
 		const yamlRaw = readFileSync(join(resolve(opts.agentDir), "agent.yaml"), "utf-8");
 		const m = yamlRaw.match(/^name:\s*(.+)$/m);
 		if (m) agentName = m[1].trim();
+		const parsed = yaml.load(yamlRaw) as any;
+		if (parsed?.model?.routing && typeof parsed.model.routing === "object") {
+			modelRouting = parsed.model.routing as RoutingConfig;
+		}
 	} catch { /* fallback to default */ }
 	// Re-read on every request so `npm run build` is picked up live without a server restart.
 	// The file sits in the OS page cache, so the per-request cost is negligible.
@@ -830,7 +838,18 @@ export async function startVoiceServer(opts: VoiceServerOptions): Promise<() => 
 		sendToBrowser({ type: "transcript", role: "assistant",
 			text: `Running flow: ${flow.name} (${flow.steps.length} steps)` });
 
+		// Per-skill default model from each skill's SKILL.md frontmatter (`model:`).
+		// Used as a fallback when a step doesn't set its own `model`.
+		const skillModels = new Map<string, string>();
+		for (const s of await discoverSkills(opts.agentDir)) {
+			if (s.model) skillModels.set(s.name, s.model);
+		}
+
 		let runningContext = userContext;
+
+		// Observability for auto model routing (issue #48): per-step model
+		// selection plus token/cost totals, summarized in the execution log.
+		const routeLog: Array<{ step: number; skill: string; model: string; tier: string; source: string; tokens: number; costUsd: number }> = [];
 
 		for (let i = 0; i < flow.steps.length; i++) {
 			const step = flow.steps[i];
@@ -859,7 +878,22 @@ export async function startVoiceServer(opts: VoiceServerOptions): Promise<() => 
 				continue;
 			}
 
-			sendToBrowser({ type: "agent_working" as any, query: `Step ${i + 1}/${flow.steps.length}: ${step.skill}` } as any);
+			// Auto model routing (issue #48): classify the task by complexity and
+			// route it to the appropriate model. Explicit per-step model wins, then
+			// the skill's declared default, then automatic classification, then the
+			// primary model as fallback.
+			const route = resolveRoutedModel({
+				stepModel: step.model,
+				skillModel: skillModels.get(step.skill),
+				classifyText: `${step.skill} ${step.prompt}`,
+				routing: modelRouting,
+				primaryModel: opts.model,
+			});
+			const stepModel = route.model;
+			const routeNote = route.source === "auto" ? `auto/${route.tier}` : route.source;
+
+			sendToBrowser({ type: "agent_working" as any,
+				query: `Step ${i + 1}/${flow.steps.length}: ${step.skill}${stepModel ? ` (${stepModel} · ${routeNote})` : ""}` } as any);
 
 			const prompt = `Use the skill "${step.skill}" (load it with /skill:${step.skill}).
 ${step.prompt.replace(/\{input\}/g, userContext)}
@@ -870,22 +904,50 @@ ${runningContext}`;
 			const result = query({
 				prompt,
 				dir: opts.agentDir,
-				model: opts.model,
+				model: stepModel,
 				env: opts.env,
 			});
 
 			let stepOutput = "";
+			let stepTokens = 0;
+			let stepCost = 0;
 			for await (const msg of result) {
 				if (msg.type === "assistant" && msg.content) stepOutput += msg.content;
+				if (msg.type === "assistant" && msg.usage) {
+					stepTokens += msg.usage.totalTokens ?? 0;
+					stepCost += msg.usage.costUsd ?? 0;
+				}
 				if (msg.type === "tool_use") sendToBrowser({ type: "tool_call", toolName: msg.toolName, args: msg.args } as any);
 				if (msg.type === "tool_result") sendToBrowser({ type: "tool_result", toolName: msg.toolName, content: msg.content, isError: msg.isError } as any);
 			}
+
+			routeLog.push({
+				step: i + 1, skill: step.skill, model: stepModel ?? "(default)",
+				tier: route.tier ?? "-", source: route.source, tokens: stepTokens, costUsd: stepCost,
+			});
 
 			runningContext += `\n\n[Step ${i + 1} result (${step.skill})]: ${stepOutput}`;
 			sendToBrowser({ type: "agent_done" as any, result: `Step ${i + 1} complete` } as any);
 		}
 
-		sendToBrowser({ type: "transcript", role: "assistant", text: `Flow "${flow.name}" completed.` });
+		// Routing summary — model selected per task plus token/cost totals (issue #48).
+		if (routeLog.length > 0) {
+			const totalTokens = routeLog.reduce((a, r) => a + r.tokens, 0);
+			const totalCost = routeLog.reduce((a, r) => a + r.costUsd, 0);
+			const autoSteps = routeLog.filter((r) => r.source === "auto");
+			const lightCount = autoSteps.filter((r) => r.tier === "lightweight").length;
+			console.log(dim(`[routing] Flow "${flow.name}" summary — ${routeLog.length} steps, ${totalTokens} tokens, $${totalCost.toFixed(4)}`));
+			for (const r of routeLog) {
+				console.log(dim(`[routing]   step ${r.step} ${r.skill}: ${r.model} [${r.source}${r.tier !== "-" ? "/" + r.tier : ""}] ${r.tokens} tok $${r.costUsd.toFixed(4)}`));
+			}
+			const autoNote = autoSteps.length > 0
+				? ` · auto-routed ${autoSteps.length} (${lightCount} → lightweight)`
+				: "";
+			sendToBrowser({ type: "transcript", role: "assistant",
+				text: `Flow "${flow.name}" completed. ${routeLog.length} steps · ${totalTokens} tokens · $${totalCost.toFixed(4)}${autoNote}` });
+		} else {
+			sendToBrowser({ type: "transcript", role: "assistant", text: `Flow "${flow.name}" completed.` });
+		}
 	}
 
 	// ── File API helpers ────────────────────────────────────────────────
@@ -2555,7 +2617,7 @@ return false;
 
 		} else if (url.pathname === "/api/flows/save" && req.method === "POST") {
 			const body = await readBody(req);
-			let parsed: { name: string; description: string; steps: { skill: string; prompt: string; channel?: string }[] };
+			let parsed: { name: string; description: string; steps: { skill: string; prompt: string; channel?: string; model?: string }[] };
 			try { parsed = JSON.parse(body); } catch { return jsonReply(res, 400, { error: "Invalid JSON" }); }
 			if (!parsed.name || !parsed.steps?.length) return jsonReply(res, 400, { error: "Missing name or steps" });
 			try {

--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -7,6 +7,7 @@ export interface SkillFlowStep {
 	skill: string;
 	prompt: string;
 	channel?: string;
+	model?: string;
 }
 
 export interface SkillFlowDefinition {
@@ -68,6 +69,7 @@ export async function discoverWorkflows(agentDir: string): Promise<WorkflowMetad
 								skill: String(s.skill || ""),
 								prompt: String(s.prompt || ""),
 								...(s.channel ? { channel: String(s.channel) } : {}),
+								...(s.model ? { model: String(s.model) } : {}),
 							})),
 						} : { type: "basic" as const }),
 					});
@@ -113,6 +115,7 @@ export async function loadFlowDefinition(filePath: string): Promise<SkillFlowDef
 			skill: String(s.skill || ""),
 			prompt: String(s.prompt || ""),
 			...(s.channel ? { channel: String(s.channel) } : {}),
+			...(s.model ? { model: String(s.model) } : {}),
 		})),
 	};
 }
@@ -130,7 +133,7 @@ export async function saveFlowDefinition(agentDir: string, flow: SkillFlowDefini
 	const content = yaml.dump({
 		name: flow.name,
 		description: flow.description || "",
-		steps: flow.steps.map((s) => ({ skill: s.skill, prompt: s.prompt, ...(s.channel ? { channel: s.channel } : {}) })),
+		steps: flow.steps.map((s) => ({ skill: s.skill, prompt: s.prompt, ...(s.channel ? { channel: s.channel } : {}), ...(s.model ? { model: s.model } : {}) })),
 	}, { lineWidth: 120 });
 	await writeFile(filePath, content, "utf-8");
 	return filePath;

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -1,0 +1,111 @@
+// Tests for the resolution priority chain (step > skill > auto > fallback) and
+// the classifier's safety default (ambiguous tasks resolve to reasoning).
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+	classifyTaskTier,
+	resolveModelAlias,
+	resolveRoutedModel,
+	type RoutingConfig,
+} from "../src/model-routing.ts";
+
+const routing: RoutingConfig = {
+	lightweight: "openai:gpt-4o-mini",
+	reasoning: "openai:gpt-4o",
+};
+
+// ── classifyTaskTier ───────────────────────────────────────────────────
+
+test("classifies lightweight task types as lightweight", () => {
+	assert.equal(classifyTaskTier("summarize the pull request diff"), "lightweight");
+	assert.equal(classifyTaskTier("extract the linked issue number"), "lightweight");
+	assert.equal(classifyTaskTier("format the report as markdown"), "lightweight");
+});
+
+test("classifies reasoning task types as reasoning", () => {
+	assert.equal(classifyTaskTier("analyze the security implications"), "reasoning");
+	assert.equal(classifyTaskTier("plan a multi-step remediation"), "reasoning");
+	assert.equal(classifyTaskTier("validate the truth score"), "reasoning");
+});
+
+test("unknown tasks default to reasoning (never silently downgrade quality)", () => {
+	assert.equal(classifyTaskTier("frobnicate the widget"), "reasoning");
+	assert.equal(classifyTaskTier(""), "reasoning");
+});
+
+test("a task matching both tiers resolves to reasoning", () => {
+	// "summarize" (lightweight) + "analyze" (reasoning) → reasoning wins.
+	assert.equal(classifyTaskTier("summarize and analyze the results"), "reasoning");
+});
+
+test("user rules take precedence over the built-in defaults", () => {
+	// "analyze" would default to reasoning, but a user rule forces lightweight.
+	const rules = [{ tier: "lightweight" as const, match: ["analyze"] }];
+	assert.equal(classifyTaskTier("analyze the log lines", rules), "lightweight");
+});
+
+// ── resolveModelAlias ──────────────────────────────────────────────────
+
+test("resolves tier aliases and passes literal model ids through", () => {
+	assert.equal(resolveModelAlias("lightweight", routing), "openai:gpt-4o-mini");
+	assert.equal(resolveModelAlias("reasoning", routing), "openai:gpt-4o");
+	assert.equal(resolveModelAlias("anthropic:claude-sonnet-4-5", routing), "anthropic:claude-sonnet-4-5");
+	assert.equal(resolveModelAlias(undefined, routing), undefined);
+});
+
+// ── resolveRoutedModel priority chain ──────────────────────────────────
+
+test("explicit per-step model wins over everything", () => {
+	const r = resolveRoutedModel({
+		stepModel: "openai:gpt-4o",
+		skillModel: "openai:gpt-4o-mini",
+		classifyText: "summarize the diff",
+		routing,
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-4o");
+	assert.equal(r.source, "step");
+});
+
+test("per-skill model wins when no step model is set", () => {
+	const r = resolveRoutedModel({
+		skillModel: "lightweight",
+		classifyText: "analyze the diff",
+		routing,
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-4o-mini");
+	assert.equal(r.source, "skill");
+});
+
+test("auto classification routes lightweight tasks to the cheap model", () => {
+	const r = resolveRoutedModel({
+		classifyText: "summarize the pull request",
+		routing,
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-4o-mini");
+	assert.equal(r.tier, "lightweight");
+	assert.equal(r.source, "auto");
+});
+
+test("routing stays opt-in — no routing block falls back to primary", () => {
+	const r = resolveRoutedModel({
+		classifyText: "summarize the pull request",
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-5-reasoning");
+	assert.equal(r.source, "fallback");
+});
+
+test("disabled routing falls back to primary", () => {
+	const r = resolveRoutedModel({
+		classifyText: "summarize the pull request",
+		routing: { ...routing, enabled: false },
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-5-reasoning");
+	assert.equal(r.source, "fallback");
+});

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -1,49 +1,57 @@
-// Tests for the resolution priority chain (step > skill > auto > fallback) and
-// the classifier's safety default (ambiguous tasks resolve to reasoning).
+// Tests for the resolution priority chain (step > skill > auto > fallback), the
+// LLM classifier (via an injected fake query), the keyword fallback, and a
+// save -> load roundtrip proving step `model` survives the YAML plumbing.
 
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
-	classifyTaskTier,
+	classifyByKeywords,
 	resolveModelAlias,
 	resolveRoutedModel,
 	type RoutingConfig,
+	type RouteQuery,
 } from "../src/model-routing.ts";
+import { saveFlowDefinition, loadFlowDefinition } from "../src/workflows.ts";
 
 const routing: RoutingConfig = {
 	lightweight: "openai:gpt-4o-mini",
 	reasoning: "openai:gpt-4o",
 };
 
-// ── classifyTaskTier ───────────────────────────────────────────────────
+// A fake injected query that always "answers" with the given text.
+function fakeQuery(answer: string): RouteQuery {
+	return () => (async function* () {
+		yield { type: "assistant", content: answer };
+	})();
+}
 
-test("classifies lightweight task types as lightweight", () => {
-	assert.equal(classifyTaskTier("summarize the pull request diff"), "lightweight");
-	assert.equal(classifyTaskTier("extract the linked issue number"), "lightweight");
-	assert.equal(classifyTaskTier("format the report as markdown"), "lightweight");
-});
+// ── classifyByKeywords (offline fallback) ──────────────────────────────
 
-test("classifies reasoning task types as reasoning", () => {
-	assert.equal(classifyTaskTier("analyze the security implications"), "reasoning");
-	assert.equal(classifyTaskTier("plan a multi-step remediation"), "reasoning");
-	assert.equal(classifyTaskTier("validate the truth score"), "reasoning");
+test("keyword fallback classifies lightweight and reasoning verbs", () => {
+	assert.equal(classifyByKeywords("summarize the pull request diff"), "lightweight");
+	assert.equal(classifyByKeywords("analyze the security implications"), "reasoning");
 });
 
 test("unknown tasks default to reasoning (never silently downgrade quality)", () => {
-	assert.equal(classifyTaskTier("frobnicate the widget"), "reasoning");
-	assert.equal(classifyTaskTier(""), "reasoning");
+	assert.equal(classifyByKeywords("frobnicate the widget"), "reasoning");
+	assert.equal(classifyByKeywords(""), "reasoning");
 });
 
-test("a task matching both tiers resolves to reasoning", () => {
-	// "summarize" (lightweight) + "analyze" (reasoning) → reasoning wins.
-	assert.equal(classifyTaskTier("summarize and analyze the results"), "reasoning");
+test("bare 'search' no longer forces reasoning, but 'research' still does", () => {
+	// Previously "search" was in the reasoning list, so this whole step went
+	// expensive; now the lightweight "summarize" verb wins.
+	assert.equal(classifyByKeywords("search the logs and summarize them"), "lightweight");
+	assert.equal(classifyByKeywords("research the root cause"), "reasoning");
+	assert.equal(classifyByKeywords("investigate the regression"), "reasoning");
 });
 
-test("user rules take precedence over the built-in defaults", () => {
-	// "analyze" would default to reasoning, but a user rule forces lightweight.
+test("user rules take precedence over defaults", () => {
 	const rules = [{ tier: "lightweight" as const, match: ["analyze"] }];
-	assert.equal(classifyTaskTier("analyze the log lines", rules), "lightweight");
+	assert.equal(classifyByKeywords("analyze the log lines", rules), "lightweight");
 });
 
 // ── resolveModelAlias ──────────────────────────────────────────────────
@@ -55,10 +63,23 @@ test("resolves tier aliases and passes literal model ids through", () => {
 	assert.equal(resolveModelAlias(undefined, routing), undefined);
 });
 
+test("alias with no configured tier model warns and returns undefined", () => {
+	const warnings: string[] = [];
+	const orig = console.warn;
+	console.warn = (m?: any) => { warnings.push(String(m)); };
+	try {
+		assert.equal(resolveModelAlias("lightweight", { reasoning: "openai:gpt-4o" }), undefined);
+	} finally {
+		console.warn = orig;
+	}
+	assert.equal(warnings.length, 1);
+	assert.match(warnings[0], /routing\.lightweight is not configured/);
+});
+
 // ── resolveRoutedModel priority chain ──────────────────────────────────
 
-test("explicit per-step model wins over everything", () => {
-	const r = resolveRoutedModel({
+test("explicit per-step model wins over everything", async () => {
+	const r = await resolveRoutedModel({
 		stepModel: "openai:gpt-4o",
 		skillModel: "openai:gpt-4o-mini",
 		classifyText: "summarize the diff",
@@ -69,8 +90,8 @@ test("explicit per-step model wins over everything", () => {
 	assert.equal(r.source, "step");
 });
 
-test("per-skill model wins when no step model is set", () => {
-	const r = resolveRoutedModel({
+test("per-skill model wins when no step model is set", async () => {
+	const r = await resolveRoutedModel({
 		skillModel: "lightweight",
 		classifyText: "analyze the diff",
 		routing,
@@ -80,19 +101,46 @@ test("per-skill model wins when no step model is set", () => {
 	assert.equal(r.source, "skill");
 });
 
-test("auto classification routes lightweight tasks to the cheap model", () => {
-	const r = resolveRoutedModel({
-		classifyText: "summarize the pull request",
-		routing,
-		primaryModel: "openai:gpt-5-reasoning",
-	});
+test("auto routing uses the injected LLM classifier", async () => {
+	const r = await resolveRoutedModel(
+		{ classifyText: "do the thing", routing, primaryModel: "openai:gpt-5-reasoning" },
+		{ query: fakeQuery("lightweight") },
+	);
 	assert.equal(r.model, "openai:gpt-4o-mini");
 	assert.equal(r.tier, "lightweight");
 	assert.equal(r.source, "auto");
 });
 
-test("routing stays opt-in — no routing block falls back to primary", () => {
-	const r = resolveRoutedModel({
+test("LLM classifier answering 'reasoning' routes to the reasoning model", async () => {
+	const r = await resolveRoutedModel(
+		{ classifyText: "do the thing", routing, primaryModel: "openai:gpt-5-reasoning" },
+		{ query: fakeQuery("reasoning") },
+	);
+	assert.equal(r.model, "openai:gpt-4o");
+	assert.equal(r.tier, "reasoning");
+});
+
+test("unparseable LLM output falls back to the keyword heuristic", async () => {
+	const r = await resolveRoutedModel(
+		{ classifyText: "xyzzy", routing, primaryModel: "openai:gpt-5-reasoning" },
+		{ query: fakeQuery("¯\\_(ツ)_/¯") },
+	);
+	assert.equal(r.tier, "reasoning"); // keyword fallback → unknown defaults to reasoning
+	assert.equal(r.source, "auto");
+});
+
+test("no injected query → keyword fallback still routes", async () => {
+	const r = await resolveRoutedModel({
+		classifyText: "summarize the pull request",
+		routing,
+		primaryModel: "openai:gpt-5-reasoning",
+	});
+	assert.equal(r.model, "openai:gpt-4o-mini");
+	assert.equal(r.source, "auto");
+});
+
+test("routing stays opt-in — no routing block falls back to primary", async () => {
+	const r = await resolveRoutedModel({
 		classifyText: "summarize the pull request",
 		primaryModel: "openai:gpt-5-reasoning",
 	});
@@ -100,12 +148,34 @@ test("routing stays opt-in — no routing block falls back to primary", () => {
 	assert.equal(r.source, "fallback");
 });
 
-test("disabled routing falls back to primary", () => {
-	const r = resolveRoutedModel({
-		classifyText: "summarize the pull request",
-		routing: { ...routing, enabled: false },
-		primaryModel: "openai:gpt-5-reasoning",
-	});
+test("disabled routing falls back to primary", async () => {
+	const r = await resolveRoutedModel(
+		{ classifyText: "summarize the pull request", routing: { ...routing, enabled: false }, primaryModel: "openai:gpt-5-reasoning" },
+		{ query: fakeQuery("lightweight") },
+	);
 	assert.equal(r.model, "openai:gpt-5-reasoning");
 	assert.equal(r.source, "fallback");
+});
+
+// ── Integration: step `model` survives the YAML roundtrip ──────────────
+
+test("step model survives saveFlowDefinition -> loadFlowDefinition", async () => {
+	const dir = await mkdtemp(join(tmpdir(), "gitagent-flow-"));
+	try {
+		const filePath = await saveFlowDefinition(dir, {
+			name: "route-test",
+			description: "roundtrip",
+			steps: [
+				{ skill: "summarize", prompt: "summarize {input}", model: "openai:gpt-4o-mini" },
+				{ skill: "plan", prompt: "plan the fix", model: "reasoning" },
+				{ skill: "noop", prompt: "no model here" },
+			],
+		});
+		const loaded = await loadFlowDefinition(filePath);
+		assert.equal(loaded.steps[0].model, "openai:gpt-4o-mini");
+		assert.equal(loaded.steps[1].model, "reasoning");
+		assert.equal(loaded.steps[2].model, undefined);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
 });


### PR DESCRIPTION
Addresses #48

## Summary

Adds **automatic model routing** for SkillFlows. Each step is classified by
complexity at runtime and routed to the right model — lightweight tasks
(summarize / extract / classify / transform) run on a cheaper model, while
reasoning-intensive tasks (planning / decision-making / tool orchestration)
stay on the configured reasoning model. Reduces token usage and cost without
sacrificing quality on complex steps.

## How it works

Model resolution per step, in priority order:

1. Explicit per-step `model:` in `workflows/*.yaml`
2. Per-skill `model:` in `SKILL.md`
3. Automatic classification via `model.routing` tiers
4. Fallback to the `preferred` model

Unknown / ambiguous tasks default to **reasoning**, so cost optimization never
silently degrades quality. Routing is **opt-in** — active only when a
`model.routing` block is present, so existing agents are unaffected.

## Configuration (`agent.yaml`)

```yaml
model:
  preferred: "openai:gpt-5-reasoning"
  routing:
    lightweight: "openai:gpt-4o-mini"
    reasoning:   "openai:gpt-5-reasoning"
```

## Scope note

Routing is applied at the **SkillFlow step** level — where GitAgent runs
discrete tasks in sequence. Per-turn routing inside a single agent loop would
need deeper `pi-agent-core` changes; happy to follow up if that's preferred.
