### PR TITLE
fix(sandbox): align E2B sandbox with current gitmachine API

### DIFF
--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -70,25 +70,39 @@ export async function createSandboxContext(
 		);
 	}
 
-	const gitMachine = new gitmachine.GitMachine({
-		provider: config.provider,
+	const apiKey = process.env.E2B_API_KEY;
+	if (!apiKey) {
+		throw new Error(
+			"Sandbox mode requires an E2B API key. Set E2B_API_KEY in your environment.\n" +
+			"Get one at https://e2b.dev (Dashboard → API Keys).",
+		);
+	}
+
+	// gitmachine splits VM creation (E2BMachine) from git lifecycle (GitMachine):
+	// build the provider machine first, then hand it to GitMachine. Note the key
+	// names differ between the two — E2BMachine uses `envs`, GitMachine uses `env`.
+	const machine = new gitmachine.E2BMachine({
+		apiKey,
 		template: config.template,
 		timeout: config.timeout,
+		envs: config.envs,
+	});
+
+	const gitMachine = new gitmachine.GitMachine({
+		machine,
 		repository,
 		token,
 		session: config.session,
 		autoCommit: config.autoCommit ?? true,
-		envs: config.envs,
+		env: config.envs,
 	});
 
-	// The repo path inside the sandbox is determined by gitmachine after start().
-	// Convention: /home/user/<repo-name>
-	const repoName = repository.split("/").pop()?.replace(/\.git$/, "") || "repo";
-	const repoPath = `/home/user/${repoName}`;
+	// gitmachine clones into a fixed path inside the VM (/home/user/repo).
+	const repoPath = "/home/user/repo";
 
 	return {
 		gitMachine,
-		machine: gitMachine.machine,
+		machine,
 		repoPath,
 	};
 }


### PR DESCRIPTION
`sandbox.ts` was written against an **outdated gitmachine API**. It passed
`provider: "e2b"` to `GitMachine`, but the current gitmachine splits VM
creation (`E2BMachine`) from git lifecycle (`GitMachine`) — `GitMachine`
expects a ready-built `machine` instance. With none passed, `this.machine`
was `undefined` and `start()` threw. The feature couldn't run at all,
regardless of a valid E2B key.

## Fix

Construct the `E2BMachine` first, then hand it to `GitMachine` (the pattern
gitmachine's README documents). Four corrections:

1. Build `E2BMachine({ apiKey, template, timeout, envs })` and pass it as `machine`
2. `GitMachine` uses `env` (singular); `E2BMachine` uses `envs` (plural)
3. Add an explicit `E2B_API_KEY` check with a helpful error
4. Fix `repoPath` to gitmachine's fixed `/home/user/repo`; return the built
   machine (was `gitMachine.machine`, which is private → undefined)

Scope: a single file, `src/sandbox.ts` (+22 / −8).

## Verification

- **gitmachine standalone** — confirmed working (boots a VM, clones a repo,
  runs commands in isolation).
- **gitagent `--sandbox` end-to-end** — VM boots → repo clones → the agent's
  `cli` tool runs **inside** the sandbox: