### PR TITLE
fix(tool-loader): enable image output from declarative tools via data URI

### DIFF
--- a/src/tool-loader.ts
+++ b/src/tool-loader.ts
@@ -118,6 +118,19 @@ function createDeclarativeTool(
 
 					// Try parsing JSON output
 					let text = stdout.trim();
+
+					// Detect data URI — works regardless of field naming in user scripts
+					if (text.startsWith("data:image/") && text.includes(";base64,")) {
+						const commaIndex = text.indexOf(",");
+						const mimeType = text.slice(5, commaIndex).split(";")[0];
+						const data = text.slice(commaIndex + 1).replace(/\s/g, "");
+						resolve({
+							content: [{ type: "image", data, mimeType }],
+							details: undefined,
+						});
+						return;
+					}
+
 					try {
 						const parsed = JSON.parse(text);
 						if (parsed.text) text = parsed.text;

--- a/src/tool-loader.ts
+++ b/src/tool-loader.ts
@@ -119,16 +119,25 @@ function createDeclarativeTool(
 					// Try parsing JSON output
 					let text = stdout.trim();
 
-					// Detect data URI — works regardless of field naming in user scripts
-					if (text.startsWith("data:image/") && text.includes(";base64,")) {
-						const commaIndex = text.indexOf(",");
-						const mimeType = text.slice(5, commaIndex).split(";")[0];
-						const data = text.slice(commaIndex + 1).replace(/\s/g, "");
-						resolve({
-							content: [{ type: "image", data, mimeType }],
-							details: undefined,
-						});
-						return;
+					// Detect data URI — works regardless of field naming in user scripts.
+					// Scan lines so stray log output before the URI doesn't break detection.
+					const dataUriLine = text.split("\n").find(
+						line => line.startsWith("data:image/") && line.includes(";base64,"),
+					);
+					if (dataUriLine) {
+						const commaIndex = dataUriLine.indexOf(",");
+						// Slice past the leading "data:" prefix (5 chars) to get "image/jpeg;base64"
+						const mimeType = dataUriLine.slice(5, commaIndex).split(";")[0];
+						const data = dataUriLine.slice(commaIndex + 1).replace(/\s/g, "");
+						const allowedMimeTypes = ["image/jpeg", "image/png", "image/gif", "image/webp"];
+						if (data && allowedMimeTypes.includes(mimeType)) {
+							resolve({
+								content: [{ type: "image", data, mimeType }],
+								details: undefined,
+							});
+							return;
+						}
+						// Fall through to text/JSON handling if data is empty or mime type unsupported
 					}
 
 					try {


### PR DESCRIPTION
## Problem

Declarative YAML tools that return image data (e.g. a custom `read_image` tool) were broken silently. `tool-loader.ts` always wrapped tool output as `type: "text"`, so the model received raw base64 characters as plain text instead of an image content block. The tool ran without errors, making it impossible for users to know why vision analysis wasn't working — the model would hallucinate a description instead.

## Fix

Added data URI detection in `tool-loader.ts`. When a tool's script outputs a line in the format:

data:image/jpeg;base64,<base64data>



The loader parses the mime type and base64 data from the URI and returns a proper `type: "image"` content block to the model. Internal whitespace is stripped to handle scripts that don't normalize base64 output.

## Why Data URI

Avoids any field naming convention — users can name their script variables anything they want. The data URI format is a web standard and self-describing. No changes needed to the YAML tool definition.

## Provider Support

Works across all providers. `pi-ai`'s shared `transform-messages` layer handles image content uniformly — vision-capable models receive the actual image, non-vision models automatically receive `"(tool image omitted: model does not support images)"` with no extra handling required.

## Testing

Tested with a custom `read_image` declarative tool on a JPEG file using a vision-capable model. Model correctly described the image contents after this fix.