### PR TITLE
fix(index): use GEMINI_API_KEY for google provider startup validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -512,7 +512,7 @@ async function main(): Promise<void> {
 	const apiKeyEnvVars: Record<string, string> = {
 		anthropic: "ANTHROPIC_API_KEY",
 		openai: "OPENAI_API_KEY",
-		google: "GOOGLE_API_KEY",
+		google: "GEMINI_API_KEY",
 		xai: "XAI_API_KEY",
 		groq: "GROQ_API_KEY",
 		mistral: "MISTRAL_API_KEY",


### PR DESCRIPTION
## Problem
The startup validation in `index.ts` checked `GOOGLE_API_KEY` for the
`google:` provider, but pi-ai's `env-api-keys.js` uses `GEMINI_API_KEY`
for actual API calls.

This caused two issues:
- Users setting only `GEMINI_API_KEY` got a crash at startup:
  `Error: GOOGLE_API_KEY environment variable is not set`
- Users had to set both keys to get the `google:` provider working,
  with no indication that two separate keys were needed

## Fix
Changed the startup env var check for the `google:` provider from
`GOOGLE_API_KEY` to `GEMINI_API_KEY`, aligning with what pi-ai uses
for authentication.

## Impact
- One-line change in `index.ts`
- Users now only need `GEMINI_API_KEY` for the `google:` provider
- No functional change to API behavior — only the startup guard is updated
