### PR TITLE
chore(test): run all test suites, not just test/*.test.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "test": "node --test test/*.test.ts --experimental-strip-types"
+    "test": "node --test --experimental-strip-types \"test/**/*.test.ts\" \"src/**/__tests__/*.test.ts\""
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Problem

The test script globbed only `test/*.test.ts`:

```json
"test": "node --test test/*.test.ts --experimental-strip-types"
```

So the suites under `src/**/__tests__/` (memory, sandbox-memory, skill-learner, task-tracker) and `src/__tests__/telemetry.test.ts` were **never executed by `npm test` or CI** — silently non-running tests.

## What I checked first

Ran those orphaned files directly. They're currently `it.todo(...)` **placeholder stubs** with no bodies, so they report as TODO markers, not failures. That means flipping the glob is safe today (CI stays green) and, more importantly, any *real* tests added under those paths from now on will actually run instead of being silently ignored.

## Fix

```json
"test": "node --test --experimental-strip-types \"test/**/*.test.ts\" \"src/**/__tests__/*.test.ts\""
```

Recursive globs covering both locations.

## Result

`npm test` now discovers every suite:

```
ℹ tests 45
ℹ pass 27
ℹ fail 0
ℹ todo 18
```

27 real tests pass, 18 TODO stubs surface as TODO (not failures), 0 failures.

Follow-up flagged from #71; kept as its own one-line change.