### PR TITLE
fix: Windows compatibility for hooks and cli tool

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 import { readFile } from "fs/promises";
-import { join, resolve, relative, isAbsolute } from "path";
+import { join, resolve, relative, isAbsolute, sep } from "path";
 import yaml from "js-yaml";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 
@@ -67,7 +67,7 @@ async function executeHook(
 		const resolvedScript = resolve(scriptPath);
 		const allowedBase = resolve(baseDir);
 		const rel = relative(allowedBase, resolvedScript);
-		const escapesBase = rel !== "" && (rel.startsWith("..") || isAbsolute(rel));
+		const escapesBase = rel !== "" && (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel));
 		if (escapesBase) {
 			reject(new Error(`Hook "${hook.script}" escapes its base directory`));
 			return;
@@ -99,7 +99,7 @@ async function executeHook(
 
 		child.on("error", (err: any) => {
 			clearTimeout(timeout);
-			if (err.code === "ENOENT" && err.syscall === "spawn sh") {
+			if (err.code === "ENOENT" && err.path === "sh") {
 				reject(new Error(
 					`Hook "${hook.script}" could not run: no POSIX shell ("sh") found on this system. ` +
 					`Hook scripts require a POSIX shell — on Windows, run gitagent from Git Bash or WSL, ` +

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -97,8 +97,16 @@ async function executeHook(
 			reject(new Error(`Hook "${hook.script}" timed out after 10s`));
 		}, 10_000);
 
-		child.on("error", (err) => {
+		child.on("error", (err: any) => {
 			clearTimeout(timeout);
+			if (err.code === "ENOENT" && err.syscall === "spawn sh") {
+				reject(new Error(
+					`Hook "${hook.script}" could not run: no POSIX shell ("sh") found on this system. ` +
+					`Hook scripts require a POSIX shell — on Windows, run gitagent from Git Bash or WSL, ` +
+					`or ensure "sh" is on PATH.`,
+				));
+				return;
+			}
 			reject(new Error(`Hook "${hook.script}" failed to start: ${err.message}`));
 		});
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process";
 import { readFile } from "fs/promises";
-import { join, resolve } from "path";
+import { join, resolve, relative, isAbsolute } from "path";
 import yaml from "js-yaml";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 
@@ -66,7 +66,9 @@ async function executeHook(
 		// Path traversal guard: ensure script doesn't escape its base directory
 		const resolvedScript = resolve(scriptPath);
 		const allowedBase = resolve(baseDir);
-		if (!resolvedScript.startsWith(allowedBase + "/") && resolvedScript !== allowedBase) {
+		const rel = relative(allowedBase, resolvedScript);
+		const escapesBase = rel !== "" && (rel.startsWith("..") || isAbsolute(rel));
+		if (escapesBase) {
 			reject(new Error(`Hook "${hook.script}" escapes its base directory`));
 			return;
 		}

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -24,10 +24,11 @@ export function createCliTool(cwd: string, defaultTimeout?: number): AgentTool<t
 					return;
 				}
 
-				const child = spawn("sh", ["-c", command], {
+				const child = spawn(command, {
 					cwd,
 					stdio: ["ignore", "pipe", "pipe"],
 					env: { ...process.env },
+					shell: true,
 				});
 
 				let output = "";

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -24,6 +24,9 @@ export function createCliTool(cwd: string, defaultTimeout?: number): AgentTool<t
 					return;
 				}
 
+				// shell: true routes through cmd.exe on Windows and /bin/sh elsewhere.
+				// cmd.exe has different quoting/escaping rules than sh (e.g. &, |, ^, >,
+				// embedded quotes behave differently) — commands may need to account for this.
 				const child = spawn(command, {
 					cwd,
 					stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Fixes #74

## Summary
Fixes two Windows-specific bugs that caused `pre_tool_use` hooks (e.g. a
safety-check blocking `rm -rf`) to silently fail on Windows, and the `cli`
tool to fail entirely outside Git Bash/WSL.

- **Hook path-containment check was hardcoded to POSIX separators.** The
  check testing whether a hook script stays inside its base directory did
  `resolvedScript.startsWith(allowedBase + "/")` — hardcoding `/`. On
  Windows, `path.resolve()` returns backslash-separated paths, so this
  check always failed, even for correctly-nested scripts. Combined with
  `runHooks()`'s fail-open error handling, this silently disabled every
  hook on Windows with no clear indication why. Replaced with
  `path.relative()`, which correctly handles OS-specific separators on
  Windows, macOS, and Linux.

- **`cli` tool hardcoded `spawn("sh", ["-c", command])`.** `sh` isn't
  available on native Windows (PowerShell/cmd) without Git Bash or WSL
  installed, so every `cli` tool call failed with `spawn sh ENOENT` there.
  Switched to `spawn(command, { shell: true })`, so Node picks the correct
  native shell per OS (`cmd.exe` on Windows, `/bin/sh` on macOS/Linux) —
  no behavior change on macOS/Linux, since that already resolves to
  `/bin/sh`.

- Also added a clearer error message when a hook script genuinely can't
  run because no POSIX shell is available at all (e.g. native PowerShell
  without Git Bash/WSL), instead of a raw `ENOENT`.

## Test plan
- [x] Reproduced both bugs locally by forcing Windows path semantics
      (`path.win32`) and a stripped `PATH` without requiring an actual
      Windows machine
- [x] Verified `path.relative()` fix passes for correctly-nested Windows
      paths and still correctly rejects genuine traversal attempts
- [x] Confirmed on an actual Windows machine (Git Bash): `cli` tool and
      hook execution both work correctly after the fix
- [x] Confirmed on macOS: no behavior change for either the `cli` tool or
      hook execution (regression check)