### PR TITLE
docs: add SECURITY.md for vulnerability disclosure process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released version on `main`. Older versions are not backported.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for security vulnerabilities.
+
+Instead, use one of the following private channels:
+
+1. **GitHub Private Vulnerability Reporting** (preferred) — go to the **Security** tab on this repository and select **Report a vulnerability**.
+2. **Email** — [shreyas@lyzr.ai](mailto:shreyas@lyzr.ai). A PGP key is available on request for encrypted reports.
+
+Please include as much detail as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce, or a proof-of-concept if available
+- Affected version/commit
+- Any suggested mitigation, if known
+
+## Response SLA
+
+- **Acknowledgment:** within 3 business days of report.
+- **Initial assessment:** within 7 business days, including severity and next steps.
+- **Fix or mitigation timeline:** communicated once the report is triaged, based on severity.
+
+We'll keep you updated as the report is investigated, and credit reporters (unless anonymity is requested) once a fix is released.
+
+## Scope
+
+This policy covers the `gitagent` CLI, SDK, and runtime in this repository. Vulnerabilities in third-party dependencies should be reported upstream, but feel free to flag them here as well if they materially affect gitagent users.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` documenting the official vulnerability disclosure process, as promised in #28.

## What's included

- **Reporting channels** — GitHub Private Vulnerability Reporting (preferred) and a direct email fallback (`shreyas@lyzr.ai`, PGP available on request)
- **What to include in a report** — description/impact, repro steps or PoC, affected version, suggested mitigation
- **Response SLA** — acknowledgment within 3 business days, initial assessment within 7 business days
- **Scope** — covers the `gitagent` CLI/SDK/runtime; third-party dependency issues should go upstream but can also be flagged here
- **Supported versions** — security fixes land on `main` only; older versions are not backported

Closes #28
