### PR TITLE
fix: use pathToFileURL for plugin entry import to support Windows paths

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir, stat, mkdir, rm } from "fs/promises";
 import { join } from "path";
+import { pathToFileURL } from "url";
 import { execFileSync } from "child_process";
 import { createRequire } from "module";
 import { homedir } from "os";
@@ -242,7 +243,11 @@ async function loadPlugin(
 			const { createPluginApi } = await import("./plugin-sdk.js");
 			const api = createPluginApi(manifest.id, pluginDir, config);
 			const entryPath = join(pluginDir, manifest.entry);
-			const mod = await import(entryPath);
+			// Node's ESM loader requires a file:// URL for absolute paths on
+			// Windows — a raw "D:\..." path is misread as a URL with protocol
+			// "d:", which the loader rejects. pathToFileURL() handles this
+			// correctly on every OS, including plain POSIX paths.
+			const mod = await import(pathToFileURL(entryPath).href);
 			if (typeof mod.register === "function") {
 				await mod.register(api);
 			} else if (typeof mod.default === "function") {


### PR DESCRIPTION
## Problem

Plugin entry points (`entry:` in `plugin.yaml`) failed to load on Windows.
`src/plugins.ts` passed the raw filesystem path directly into `import()`.
Node's ESM loader requires `file://` URLs for absolute paths on Windows —
a raw path like `D:\...\index.js` gets misread as protocol `d:` and rejected.

## Reproduced live, before the fix

Plugin "my-plugin": failed to load entry "index.js": ...
Received protocol 'd:'



Plugin silently failed to load while gitagent kept running otherwise.

## Fix

```ts
const mod = await import(pathToFileURL(entryPath).href);
pathToFileURL() converts the path into the correct file:// format on
every OS.
```
## Testing
npm run build / npm test — clean, all 27 tests pass.
Verified on POSIX (Mac): plugin still loads correctly, no regression.
Verified on Windows: reproduced the exact error before the fix, confirmed it's resolved after.
Refs #30 (Windows plugin-loading finding only).