### PR TITLE
fix(repo): require safe directory and opt out of pushes

### DIFF
--- a/src/sdk-types.ts
+++ b/src/sdk-types.ts
@@ -110,8 +110,10 @@ export interface GCToolDefinition {
 export interface LocalRepoOptions {
 	url: string;
 	token: string;
-	dir?: string;
+	dir: string;
 	session?: string;
+	/** Commit locally but do not push the session branch when false. */
+	autoPush?: boolean;
 }
 
 // ── Sandbox options ─────────────────────────────────────────────────────

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -137,6 +137,9 @@ export function query(options: QueryOptions): Query {
 
 		// Local repo mode
 		if (options.repo) {
+			if (!options.repo.dir) {
+				throw new Error("repo.dir is required; refusing to use the caller's working directory");
+			}
 			const token = options.repo.token || process.env.GITHUB_TOKEN || process.env.GIT_TOKEN;
 			if (!token) {
 				throw new Error("repo.token, GITHUB_TOKEN, or GIT_TOKEN is required with repo option");
@@ -144,8 +147,9 @@ export function query(options: QueryOptions): Query {
 			localSession = initLocalSession({
 				url: options.repo.url,
 				token,
-				dir: options.repo.dir || dir,
+				dir: options.repo.dir,
 				session: options.repo.session,
+				autoPush: options.repo.autoPush,
 			});
 			dir = localSession.dir;
 		}
@@ -547,7 +551,10 @@ export function query(options: QueryOptions): Query {
 
 		// Finalize local session if active
 		if (localSession) {
-			try { localSession.finalize(); } catch { /* best-effort */ }
+			try {
+				if (options.repo?.autoPush === false) localSession.cleanup();
+				else localSession.finalize();
+			} catch { /* best-effort */ }
 		}
 
 		// Stop sandbox if active
@@ -576,7 +583,10 @@ export function query(options: QueryOptions): Query {
 	})().catch(async (err) => {
 		// Finalize local session on error
 		if (localSession) {
-			try { localSession.finalize(); } catch { /* best-effort */ }
+			try {
+				if (options.repo?.autoPush === false) localSession.cleanup();
+				else localSession.finalize();
+			} catch { /* best-effort */ }
 		}
 
 		// Stop sandbox on error

--- a/src/session.ts
+++ b/src/session.ts
@@ -10,6 +10,7 @@ export interface LocalRepoOptions {
 	token: string;
 	dir: string;
 	session?: string;
+	autoPush?: boolean;
 }
 
 export interface LocalSession {
@@ -19,6 +20,7 @@ export interface LocalSession {
 	commitChanges(msg?: string): void;
 	push(): void;
 	finalize(): void;
+	cleanup(): void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
@@ -63,6 +65,15 @@ export function initLocalSession(opts: LocalRepoOptions): LocalSession {
 	if (!existsSync(dir)) {
 		execSync(`git clone --depth 1 --no-single-branch ${aUrl} ${dir}`, { stdio: "pipe" });
 	} else {
+		let repoRoot: string;
+		try {
+			repoRoot = resolve(git("rev-parse --show-toplevel", dir));
+		} catch {
+			throw new Error(`repo.dir must be an existing Git repository or an empty path: ${dir}`);
+		}
+		if (repoRoot !== dir) {
+			throw new Error(`repo.dir must be the Git repository root, not a nested path: ${dir}`);
+		}
 		git(`remote set-url origin ${aUrl}`, dir);
 		git("fetch origin", dir);
 
@@ -145,7 +156,13 @@ export function initLocalSession(opts: LocalRepoOptions): LocalSession {
 
 		finalize() {
 			localSession.commitChanges();
-			localSession.push();
+			if (opts.autoPush !== false) {
+				localSession.push();
+			}
+			localSession.cleanup();
+		},
+
+		cleanup() {
 			// Strip PAT from remote URL
 			git(`remote set-url origin ${cleanUrl(url)}`, dir);
 		},


### PR DESCRIPTION
## Summary\n\n- require an explicit repository root instead of defaulting to the caller's working directory\n- reject nested paths and non-Git directories before mutating remotes\n- add epo.autoPush: false for local commit-only sessions\n- strip PATs from remotes during cleanup on both success and failure\n\nFixes #85\n\n## Verification\n\n- 
pm run build (pass)\n- 
pm test (37 passed; 2 pre-existing MCP result-shape failures unrelated to this change)\n- git diff --check (pass)