### PR TITLE
feat(skills): add Plivo SMS and voice integrations

### DIFF
--- a/skills/plivo-sms/SKILL.md
+++ b/skills/plivo-sms/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: plivo-sms
+description: Send outbound SMS messages through the Plivo Messages API.
+---
+
+# Plivo SMS Skill
+
+Send an outbound SMS using Plivo's REST API. The script uses only Python's
+standard library and never prints the auth token.
+
+## Setup
+
+Set these environment variables (or put them in `skills/plivo-sms/.env`):
+
+```bash
+export PLIVO_AUTH_ID="your-auth-id"
+export PLIVO_AUTH_TOKEN="your-auth-token"
+export PLIVO_SMS_SOURCE="+14155551234"
+```
+
+The source number must be a Plivo number, short code, Powerpack sender, or
+approved alphanumeric sender ID for the account.
+
+## Usage
+
+```bash
+python3 scripts/send_sms.py \
+  --to "+14155559876" \
+  --text "The agent finished the task."
+```
+
+Use `--from` to override `PLIVO_SMS_SOURCE` for one message. Phone numbers
+should use E.164 format. Multiple recipients can be supplied as a comma-
+separated list; the script sends them in one Plivo request.
+
+## Requirements
+
+- Python 3.8+
+- No additional packages

--- a/skills/plivo-sms/scripts/send_sms.py
+++ b/skills/plivo-sms/scripts/send_sms.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Send an SMS through the Plivo Messages API using only the standard library."""
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+API_BASE = "https://api.plivo.com/v1/Account"
+
+
+def load_env() -> None:
+    """Load simple KEY=VALUE entries from the skill-local .env file."""
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if not env_file.exists():
+        return
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"\''))
+
+
+def send_sms(
+    destination: str,
+    text: str,
+    source: Optional[str] = None,
+    *,
+    auth_id: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    timeout: float = 30,
+) -> dict:
+    """Send one request to Plivo and return its decoded JSON response."""
+    auth_id = auth_id or os.getenv("PLIVO_AUTH_ID")
+    auth_token = auth_token or os.getenv("PLIVO_AUTH_TOKEN")
+    source = source or os.getenv("PLIVO_SMS_SOURCE")
+    missing = [
+        name
+        for name, value in (
+            ("PLIVO_AUTH_ID", auth_id),
+            ("PLIVO_AUTH_TOKEN", auth_token),
+            ("PLIVO_SMS_SOURCE", source),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing required configuration: {', '.join(missing)}")
+    if not destination.strip():
+        raise ValueError("destination must not be empty")
+    if not text:
+        raise ValueError("text must not be empty")
+
+    credentials = base64.b64encode(f"{auth_id}:{auth_token}".encode()).decode()
+    body = json.dumps({"src": source, "dst": destination, "text": text}).encode()
+    request = Request(
+        f"{API_BASE}/{auth_id}/Message/",
+        data=body,
+        headers={
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Plivo rejected the SMS ({error.code}): {detail}") from error
+    except URLError as error:
+        raise RuntimeError(f"Could not reach Plivo: {error.reason}") from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--to", required=True, dest="destination")
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--from", dest="source", help="Override PLIVO_SMS_SOURCE")
+    args = parser.parse_args()
+    load_env()
+    try:
+        result = send_sms(args.destination, args.text, args.source)
+    except (RuntimeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/plivo-voice/SKILL.md
+++ b/skills/plivo-voice/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: plivo-voice
+description: Place an outbound voice call through the Plivo Voice API.
+---
+
+# Plivo Voice Skill
+
+Place an outbound call using Plivo's REST API. Plivo fetches the supplied
+`answer_url` when the call is answered; that URL must return valid Plivo XML,
+for example `<Response><Speak>Hello from GitAgent.</Speak></Response>`.
+
+## Setup
+
+Set these environment variables (or put them in `skills/plivo-voice/.env`):
+
+```bash
+export PLIVO_AUTH_ID="your-auth-id"
+export PLIVO_AUTH_TOKEN="your-auth-token"
+export PLIVO_VOICE_SOURCE="+14155551234"
+```
+
+## Usage
+
+```bash
+python3 scripts/make_call.py \
+  --to "+14155559876" \
+  --answer-url "https://example.com/plivo/answer.xml"
+```
+
+Use `--from` to override `PLIVO_VOICE_SOURCE` and `--answer-method GET` when
+the answer endpoint expects GET instead of the default POST. The answer URL
+must be publicly reachable by Plivo; the skill intentionally does not host a
+temporary endpoint or expose credentials in the URL.
+
+## Requirements
+
+- Python 3.8+
+- No additional packages

--- a/skills/plivo-voice/scripts/make_call.py
+++ b/skills/plivo-voice/scripts/make_call.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Place an outbound call through the Plivo Voice API using the standard library."""
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+API_BASE = "https://api.plivo.com/v1/Account"
+
+
+def load_env() -> None:
+    """Load simple KEY=VALUE entries from the skill-local .env file."""
+    env_file = Path(__file__).resolve().parent.parent / ".env"
+    if not env_file.exists():
+        return
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip().strip('"\''))
+
+
+def make_call(
+    destination: str,
+    answer_url: str,
+    source: Optional[str] = None,
+    answer_method: str = "POST",
+    *,
+    auth_id: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    timeout: float = 30,
+) -> dict:
+    """Initiate one call and return Plivo's decoded JSON response."""
+    auth_id = auth_id or os.getenv("PLIVO_AUTH_ID")
+    auth_token = auth_token or os.getenv("PLIVO_AUTH_TOKEN")
+    source = source or os.getenv("PLIVO_VOICE_SOURCE")
+    missing = [
+        name
+        for name, value in (
+            ("PLIVO_AUTH_ID", auth_id),
+            ("PLIVO_AUTH_TOKEN", auth_token),
+            ("PLIVO_VOICE_SOURCE", source),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing required configuration: {', '.join(missing)}")
+    if not destination.strip():
+        raise ValueError("destination must not be empty")
+    if not answer_url.strip():
+        raise ValueError("answer_url must not be empty")
+    answer_method = answer_method.upper()
+    if answer_method not in {"GET", "POST"}:
+        raise ValueError("answer_method must be GET or POST")
+
+    credentials = base64.b64encode(f"{auth_id}:{auth_token}".encode()).decode()
+    body = json.dumps(
+        {
+            "from": source,
+            "to": destination,
+            "answer_url": answer_url,
+            "answer_method": answer_method,
+        }
+    ).encode()
+    request = Request(
+        f"{API_BASE}/{auth_id}/Call/",
+        data=body,
+        headers={
+            "Authorization": f"Basic {credentials}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Plivo rejected the call ({error.code}): {detail}") from error
+    except URLError as error:
+        raise RuntimeError(f"Could not reach Plivo: {error.reason}") from error
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--to", required=True, dest="destination")
+    parser.add_argument("--answer-url", required=True)
+    parser.add_argument("--answer-method", choices=("GET", "POST"), default="POST")
+    parser.add_argument("--from", dest="source", help="Override PLIVO_VOICE_SOURCE")
+    args = parser.parse_args()
+    load_env()
+    try:
+        result = make_call(
+            args.destination,
+            args.answer_url,
+            args.source,
+            args.answer_method,
+        )
+    except (RuntimeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a discoverable `plivo-sms` skill for outbound SMS
- add a discoverable `plivo-voice` skill for outbound calls with a Plivo XML answer URL
- use stdlib-only HTTP Basic authentication, environment/.env configuration, timeouts, and actionable API errors

Closes #83

## Validation

- python -m compileall -q skills/plivo-sms/scripts/send_sms.py skills/plivo-voice/scripts/make_call.py
- --help smoke tests for both CLIs
- mocked HTTP request smoke tests for both endpoints
- git diff --check
