### PR TITLE
fix(scheduler): chunk far-future one-shot timers

### DIFF
--- a/src/schedule-runner.ts
+++ b/src/schedule-runner.ts
@@ -6,6 +6,54 @@ import type { ServerMessage } from "./adapter.js";
 
 const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
+/** Node clamps timers above this value to a much shorter delay. */
+export const MAX_TIMEOUT_MS = 2_147_483_647;
+
+export interface ScheduledTimer {
+	cancel(): void;
+}
+
+/** Split a delay into timer-safe chunks without overflowing Node's timer limit. */
+export function splitTimeoutDelay(delayMs: number): number[] {
+	const remaining = Math.max(0, Math.floor(delayMs));
+	if (remaining === 0) return [0];
+	const chunks: number[] = [];
+	let pending = remaining;
+	while (pending > 0) {
+		const chunk = Math.min(pending, MAX_TIMEOUT_MS);
+		chunks.push(chunk);
+		pending -= chunk;
+	}
+	return chunks;
+}
+
+/** Schedule a callback across multiple safe timers when the delay is far-future. */
+export function scheduleLongTimeout(callback: () => void, delayMs: number): ScheduledTimer {
+	let cancelled = false;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const scheduleNext = (remaining: number) => {
+		if (cancelled) return;
+		const chunk = Math.min(remaining, MAX_TIMEOUT_MS);
+		timer = setTimeout(() => {
+			if (cancelled) return;
+			if (remaining > chunk) {
+				scheduleNext(remaining - chunk);
+			} else {
+				callback();
+			}
+		}, chunk);
+	};
+
+	scheduleNext(Math.max(0, Math.floor(delayMs)));
+	return {
+		cancel: () => {
+			cancelled = true;
+			if (timer) clearTimeout(timer);
+		},
+	};
+}
+
 export interface SchedulerOptions {
 	agentDir: string;
 	model?: string;
@@ -16,7 +64,7 @@ export interface SchedulerOptions {
 }
 
 const activeTasks = new Map<string, ScheduledTask>();
-const activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const activeTimers = new Map<string, ScheduledTimer>();
 const runningJobs = new Set<string>();
 
 export async function startScheduler(opts: SchedulerOptions): Promise<void> {
@@ -33,7 +81,7 @@ export async function startScheduler(opts: SchedulerOptions): Promise<void> {
 				console.log(dim(`[scheduler] "${schedule.id}" runAt is in the past — skipping`));
 				continue;
 			}
-			const timer = setTimeout(() => {
+			const timer = scheduleLongTimeout(() => {
 				executeScheduledJob(schedule, opts, true);
 			}, delay);
 			activeTimers.set(schedule.id, timer);
@@ -74,7 +122,7 @@ export function stopScheduler(): void {
 	}
 	activeTasks.clear();
 	for (const [, timer] of activeTimers) {
-		clearTimeout(timer);
+		timer.cancel();
 	}
 	activeTimers.clear();
 	console.log(dim("[scheduler] Stopped all scheduled tasks"));
@@ -136,7 +184,7 @@ export async function executeScheduledJob(schedule: ScheduleDefinition, opts: Sc
 		const task = activeTasks.get(schedule.id);
 		if (task) { task.stop(); activeTasks.delete(schedule.id); }
 		const timer = activeTimers.get(schedule.id);
-		if (timer) { clearTimeout(timer); activeTimers.delete(schedule.id); }
+		if (timer) { timer.cancel(); activeTimers.delete(schedule.id); }
 		console.log(dim(`[scheduler] "${schedule.id}" auto-disabled (run-once)`));
 	}
 

--- a/test/schedule-runner.test.ts
+++ b/test/schedule-runner.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { MAX_TIMEOUT_MS, splitTimeoutDelay } from "../dist/schedule-runner.js";
+
+describe("schedule timer safety", () => {
+	it("keeps ordinary delays in one timer", () => {
+		assert.deepEqual(splitTimeoutDelay(60_000), [60_000]);
+	});
+
+	it("splits far-future delays at Node's timer limit", () => {
+		assert.deepEqual(splitTimeoutDelay(MAX_TIMEOUT_MS + 5_000), [MAX_TIMEOUT_MS, 5_000]);
+	});
+
+	it("normalizes negative and fractional delays", () => {
+		assert.deepEqual(splitTimeoutDelay(-1), [0]);
+		assert.deepEqual(splitTimeoutDelay(1_500.9), [1_500]);
+	});
+});


### PR DESCRIPTION
## Summary

- prevent far-future one-shot schedules from overflowing Node's `setTimeout` limit
- chunk delays at the platform-safe maximum while retaining cancellation on reload/stop
- add focused coverage for ordinary, far-future, negative, and fractional delays

This addresses the scheduler overflow identified in #30.

## Verification

- `npm run build`
- `npm test` (68 passed across 19 suites)
- `git diff --check`