### PR TITLE
feat: add optional You.com web search tool

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -10,5 +10,6 @@ tools:
   - read
   - write
   - memory
+  - web_search
 runtime:
   max_turns: 56

--- a/docs/web-search-integration.md
+++ b/docs/web-search-integration.md
@@ -1,0 +1,129 @@
+# You.com Web Search Tool
+
+This document describes the You.com web search tool integration for GitAgent.
+
+## Overview
+
+The `web_search` tool allows GitAgent to search the web using You.com's Search API, providing access to current web information, research, news, and general queries.
+
+## Features
+
+- **Keyless operation**: Works without API key (100 free searches/day per IP)
+- **Authenticated operation**: Enhanced features with `YDC_API_KEY`
+- **Graceful error handling**: Clear error messages and fallback behavior
+- **Configurable results**: Customizable result count (1-50 results)
+- **Combined results**: Includes both web and news results
+- **Proper attribution**: Includes source URLs, titles, and snippets
+
+## Configuration
+
+### Environment Variables
+
+- `YDC_API_KEY` (optional): You.com API key for authenticated access
+  - Without key: Uses keyless endpoint with 100 searches/day limit
+  - With key: Higher quotas and enhanced features
+
+### Agent Configuration
+
+Add `web_search` to your agent's tools list in `agent.yaml`:
+
+```yaml
+tools:
+  - cli
+  - read
+  - write
+  - memory
+  - web_search  # Add this line
+```
+
+## Usage
+
+### CLI Usage
+
+```bash
+# Basic usage (will use web_search if configured)
+gitagent --prompt "Search for latest TypeScript features"
+
+# With specific tool selection
+gitagent --prompt "Find information about AI agents" --allowed-tools web_search,read,write
+```
+
+### SDK Usage
+
+```typescript
+import { query } from 'gitagent';
+
+for await (const msg of query({
+  prompt: "Research recent developments in AI",
+  tools: ['web_search']
+})) {
+  console.log(msg);
+}
+```
+
+### Parameters
+
+- `query` (string, required): Search query to find relevant web content
+- `count` (number, optional): Number of results to return (default: 10, max: 50)
+
+## API Endpoints
+
+The tool automatically selects the appropriate endpoint:
+
+- **Keyless**: `https://api.you.com/v1/agents/search` (no authentication)
+- **Authenticated**: `https://ydc-index.io/v1/search` (with `X-API-Key` header)
+
+## Error Handling
+
+The tool provides informative error messages for common scenarios:
+
+- **401 Unauthorized**: Invalid API key
+- **429 Rate Limited**: Suggests API key upgrade for keyless users
+- **5xx Server Errors**: Temporary service issues
+- **Network Errors**: Connection problems
+- **No Results**: Helpful suggestions for query refinement
+
+## Output Format
+
+Results are formatted as structured text with:
+
+1. Result count and query confirmation
+2. Numbered list of results with:
+   - Title (bold)
+   - URL
+   - Snippet/description
+3. API usage information (keyless vs authenticated)
+
+Example output:
+```
+Found 3 results for "TypeScript AI frameworks":
+
+1. **TypeScript AI Development Framework**
+   URL: https://example.com/ts-ai
+   A comprehensive framework for building AI applications with TypeScript...
+
+2. **AI Agents in TypeScript**
+   URL: https://example.com/ai-agents-ts
+   Learn how to create intelligent agents using TypeScript and modern AI...
+
+3. **TypeScript LLM Integration Guide** 
+   URL: https://example.com/llm-ts
+   Step-by-step guide for integrating large language models with TypeScript...
+
+---
+(Using keyless You.com Search API - set YDC_API_KEY for enhanced features)
+```
+
+## Security
+
+- All web content is treated as untrusted external data
+- No sensitive information is logged or exposed
+- API keys are handled securely through environment variables
+- Standard User-Agent header identifies the integration
+
+## Integration Details
+
+- **User-Agent**: `youdotcom-integration/open-gitagent-gitagent`
+- **Tool Name**: `web_search`
+- **Schema Validation**: Full TypeBox schema validation for parameters
+- **Response Structure**: Structured with `content`, `isError`, and `details` fields

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-gitagent/gitagent",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-gitagent/gitagent",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.70.2",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { createMemoryTool } from "./memory.js";
 import { createTaskTrackerTool } from "./task-tracker.js";
 import { createSkillLearnerTool } from "./skill-learner.js";
 import { createCapturePhotoTool } from "./capture-photo.js";
+import { createWebSearchTool } from "./web-search.js";
 import { createSandboxCliTool } from "./sandbox-cli.js";
 import { createSandboxReadTool } from "./sandbox-read.js";
 import { createSandboxWriteTool } from "./sandbox-write.js";
@@ -24,7 +25,7 @@ export interface BuiltinToolsConfig {
 }
 
 /**
- * Create the built-in tools (cli, read, write, memory, task_tracker, skill_learner).
+ * Create the built-in tools (cli, read, write, edit, memory, capture_photo, web_search, task_tracker, skill_learner).
  * If a SandboxContext is provided, returns sandbox-backed tools;
  * otherwise returns the standard local tools.
  */
@@ -46,6 +47,7 @@ export function createBuiltinTools(config: BuiltinToolsConfig): AgentTool<any>[]
 		createEditTool(config.dir),
 		createMemoryTool(config.dir, config.pluginMemoryLayers),
 		createCapturePhotoTool(config.dir),
+		createWebSearchTool(),
 	];
 
 	// Add learning tools if gitagentDir is available

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,0 +1,156 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+
+// Schema for the web search tool
+export const webSearchSchema = Type.Object({
+	query: Type.String({ description: "Search query to find relevant web content" }),
+	count: Type.Optional(Type.Number({ 
+		description: "Number of search results to return (default: 10, max: 50)",
+		minimum: 1,
+		maximum: 50
+	})),
+});
+
+export interface SearchResult {
+	title: string;
+	url: string;
+	snippet: string;
+}
+
+export interface YouComSearchResponse {
+	results?: {
+		web?: SearchResult[];
+		news?: SearchResult[];
+	};
+	error?: string;
+}
+
+/**
+ * Create You.com web search tool.
+ * Uses keyless API by default, falls back to authenticated API with YDC_API_KEY.
+ */
+export function createWebSearchTool(): AgentTool<typeof webSearchSchema> {
+	return {
+		name: "web_search",
+		label: "web_search", 
+		description: "Search the web using You.com for current information, research, news, and general queries. Returns titles, URLs, and snippets.",
+		parameters: webSearchSchema,
+		execute: async (
+			_toolCallId: string,
+			{ query, count = 10 }: { query: string; count?: number },
+			signal?: AbortSignal,
+		) => {
+			try {
+				const apiKey = process.env.YDC_API_KEY;
+				const searchCount = Math.min(Math.max(count, 1), 50);
+
+				// Choose endpoint based on API key availability
+				const endpoint = apiKey 
+					? "https://ydc-index.io/v1/search"
+					: "https://api.you.com/v1/agents/search";
+
+				// Build request options
+				const requestOptions: RequestInit = {
+					method: "GET",
+					signal,
+					headers: {
+						"User-Agent": "youdotcom-integration/open-gitagent-gitagent",
+						...(apiKey && { "X-API-Key": apiKey })
+					},
+				};
+
+				// Build URL with query parameters
+				const url = new URL(endpoint);
+				url.searchParams.set("query", query);
+				url.searchParams.set("count", searchCount.toString());
+
+				const response = await fetch(url, requestOptions);
+
+				if (!response.ok) {
+					if (response.status === 401) {
+						throw new Error(`Authentication failed. Please check your YDC_API_KEY environment variable.`);
+					} else if (response.status === 429) {
+						const upgradeMsg = apiKey 
+							? "API rate limit exceeded. Consider upgrading your You.com plan."
+							: "Rate limit exceeded on keyless API. Set YDC_API_KEY environment variable for higher limits.";
+						throw new Error(upgradeMsg);
+					} else if (response.status >= 500) {
+						throw new Error(`You.com service temporarily unavailable (${response.status}). Please try again later.`);
+					} else {
+						const errorText = await response.text().catch(() => "");
+						throw new Error(`You.com API error (${response.status}): ${errorText || "Unknown error"}`);
+					}
+				}
+
+				const data: YouComSearchResponse = await response.json();
+
+				if (data.error) {
+					throw new Error(`You.com API error: ${data.error}`);
+				}
+
+				// Combine web and news results
+				const webResults = data.results?.web || [];
+				const newsResults = data.results?.news || [];
+				const allResults = [...webResults, ...newsResults];
+
+				if (allResults.length === 0) {
+					return {
+						content: [{
+							type: "text",
+							text: `No results found for "${query}". Try a different search query or check your spelling.`
+						}],
+						isError: false,
+						details: { resultCount: 0, query }
+					};
+				}
+
+				// Format results
+				let resultText = `Found ${allResults.length} results for "${query}":\n\n`;
+
+				allResults.slice(0, searchCount).forEach((result, index) => {
+					resultText += `${index + 1}. **${result.title}**\n`;
+					resultText += `   URL: ${result.url}\n`;
+					resultText += `   ${result.snippet}\n\n`;
+				});
+
+				// Add API usage info
+				const apiInfo = apiKey 
+					? "(Using authenticated You.com Search API)"
+					: "(Using keyless You.com Search API - set YDC_API_KEY for enhanced features)";
+				
+				resultText += `\n---\n${apiInfo}`;
+
+				return {
+					content: [{
+						type: "text", 
+						text: resultText
+					}],
+					isError: false,
+					details: { 
+						resultCount: allResults.length, 
+						query, 
+						apiKeyUsed: !!apiKey,
+						endpoint: apiKey ? "ydc-index.io" : "api.you.com"
+					}
+				};
+
+			} catch (error) {
+				// Handle network and other errors
+				if (error instanceof Error) {
+					if (error.name === "AbortError") {
+						throw new Error("Search operation was cancelled.");
+					}
+					
+					if (error.message.includes("fetch")) {
+						throw new Error("Network error: Unable to reach You.com API. Please check your internet connection.");
+					}
+
+					// Re-throw known API errors
+					throw error;
+				}
+				
+				throw new Error(`Unexpected error during web search: ${String(error)}`);
+			}
+		},
+	};
+}

--- a/test/web-search.test.ts
+++ b/test/web-search.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { createWebSearchTool } from "../dist/tools/web-search.js";
+
+describe("Web Search Tool", () => {
+	it("should create web search tool with correct configuration", () => {
+		const tool = createWebSearchTool();
+		
+		assert.strictEqual(tool.name, "web_search");
+		assert.strictEqual(tool.label, "web_search");
+		assert.ok(tool.description.includes("You.com"));
+		assert.ok(tool.parameters);
+		assert.ok(tool.execute);
+	});
+
+	it("should have correct parameter schema", () => {
+		const tool = createWebSearchTool();
+		const schema = tool.parameters;
+		
+		assert.ok(schema.properties);
+		assert.ok(schema.properties.query);
+		assert.ok(schema.properties.count);
+		assert.strictEqual(schema.properties.query.type, "string");
+		assert.strictEqual(schema.properties.count.type, "number");
+	});
+});


### PR DESCRIPTION
This PR adds optional You.com web search integration to GitAgent, enabling agents to access current web information through You.com's Search API.

## Key Features
- Works both keyless (100 searches/day) and with YDC_API_KEY authentication
- Configurable result count (1-50) with sensible defaults
- Comprehensive error handling with informative messages
- Opt-in via agent.yaml configuration - no default behavior changes
- Full TypeScript support with schema validation

## Integration Details
- Tool name: web_search
- User-Agent: youdotcom-integration/open-gitagent-gitagent
- Follows existing GitAgent tool architecture patterns
- Maintains backward compatibility with zero breaking changes

## Usage
Add web_search to tools list in agent.yaml, then:
- CLI: gitagent --prompt "Research latest TypeScript features"
- SDK: query({ prompt: "Research AI developments", tools: ['web_search'] })

Ready for review!